### PR TITLE
タスク削除機能の実装

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,7 +1,7 @@
 class TasksController < ApplicationController
-  before_action :authenticate_user!, only: [:index, :new, :create, :show,:edit, :update]
-  before_action :set_task, only: [:show, :edit, :update]
-  before_action :check_person, only: [:show, :edit, :update]
+  before_action :authenticate_user!
+  before_action :set_task, only: [:show, :edit, :update, :destroy]
+  before_action :check_person, only: [:show, :edit, :update, :destroy]
 
   def index
     @tasks = current_user.tasks.order('created_at DESC')
@@ -27,6 +27,14 @@ class TasksController < ApplicationController
   def update
     if @task.update(task_params)
       redirect_to task_path(@task)
+    else
+      render :show
+    end
+  end
+
+  def destroy
+    if @task.destroy
+      redirect_to tasks_path
     else
       render :show
     end

--- a/app/views/tasks/_task_destroy.html.erb
+++ b/app/views/tasks/_task_destroy.html.erb
@@ -1,0 +1,19 @@
+<div class="modal fade" id="destroyModal" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="exampleModalLabel">タスクを削除</h5>
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+        <div class="modal-body">
+          <p>この操作は取り消せません。</p>
+          <p>本当に削除しますか？</p>
+        </div>
+        <div class="modal-footer">
+          <%= link_to '削除', task_path(task), method: :delete, class: "btn btn-secondary" %>
+        </div>
+      </div>
+    </div>
+  </div>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -9,9 +9,12 @@
       <%= link_to edit_task_path(@task), class: "btn btn-primary" do %>
         <i class="fas fa-edit"></i>
       <% end %>
-      <%= link_to "#", class: "btn btn-secondary" do %>
+      <button type="button" class="btn btn-secondary" data-toggle="modal" data-target="#destroyModal">
         <i class="fas fa-trash-alt"></i>
-      <% end %>
+      </button>
     </div>
   </div>
+  <%# destroyモーダル %>
+  <%= render partial: 'task_destroy', locals: { task: @task } %>
+  <%#/ モーダル %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  resources :tasks, only: [:index, :new, :create, :show, :edit, :update]
+  resources :tasks
   root to: 'home#top'
   devise_for :users
 end


### PR DESCRIPTION
# Why
- 投稿したタスクを削除できるようにするため

# What
- tasks#destroyアクションを定義
- 削除は二段階で行う
    - tasks#showのゴミ箱ボタンを押す
    - モーダルが表示され、削除ボタンを押すと削除が完了する

## 実装機能の確認
- https://gyazo.com/e005a8bbbf2d57cea363ef1fc508b39f

Closes #20 