### PR TITLE
タスク一覧ページのレスポンシブ化

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -32,3 +32,11 @@
  .add-margin-bottom-5px {
   margin-bottom: 5px;
  }
+
+ .margin-reset {
+   margin: 0 !important;
+ }
+
+ .padding-reset {
+   padding: 0 !important;
+ }

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -40,3 +40,9 @@
  .padding-reset {
    padding: 0 !important;
  }
+
+ .text-overflow {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+ }

--- a/app/assets/stylesheets/tasks.scss
+++ b/app/assets/stylesheets/tasks.scss
@@ -9,20 +9,19 @@
   font-size: 20px;
 }
 
-.tasks-wrapper {
-  display: flex;
-  flex-wrap: wrap;
-}
-
 // tasks/_task.html.erb
-.card-config {
-  width: 16rem;
-  margin: 0 16px 16px 0;
-}
-
 .card-body:hover {
   background-color: lightgrey;
   transition: 0.5s;
+}
+
+.card-title {
+  font-weight: bold;
+  color: #212529;
+}
+
+.card-text {
+  color: #212529
 }
 
 //////////////////////////////
@@ -36,7 +35,6 @@
   border-radius: 10px;
   display: flex;
   justify-content: space-between;
-  // border: 1px solid darkgray;
   padding: 10px;
 }
 

--- a/app/views/home/_sign_in_top.html.erb
+++ b/app/views/home/_sign_in_top.html.erb
@@ -7,7 +7,7 @@
     <i class="fas fa-plus-circle"></i> 新規作成
   <% end %>
   <%# タスク一覧表示部分 %>
-  <div class="tasks-wrapper">
+  <div class="row w-100 margin-reset">
     <%= render partial: 'tasks/task', collection: @my_tasks %>
   </div>
 </div>

--- a/app/views/tasks/_task.html.erb
+++ b/app/views/tasks/_task.html.erb
@@ -1,10 +1,10 @@
-<div class="card card-config shadow-sm">
-  <%= link_to task_path(task), style: "text-decoration: none;  height: 100%;" do %>
-    <div class="card-body" style="color: black;  height: 100%;">
-      <h5 class="card-title">
+<div class="col-xl-2 col-lg-3 col-md-3 col-5 mr-3 mb-3 shadow padding-reset">
+  <%= link_to task_path(task), style: "text-decoration: none;", class: "w-100" do %>
+    <div class="card-body">
+      <p class="card-title text-overflow">
         <%= task.title %>
       </h5>
-      <p class="card-text">
+      <p class="card-text text-overflow">
         <%= task.purpose %>
       </p>
     </div>


### PR DESCRIPTION
# Why
* タスク一覧の見た目をよくするため
* 余分なCSSを省きコードの可読性を上げるため

# What
* Bootstrapのクラスでレイアウトを調整
* タスクタイトル/目的が長いときは三点リーダ「...」で省略
* タスクカードの高さが一定になるよう変更（省略機能により自動的に実装）

## 実装の様子
https://gyazo.com/df7d07ff261278498c6bfa959ed09f43

close #33 