### PR TITLE
ユーザー名の最大値を10文字に変更

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
-  validates :nickname, presence: true
+  validates :nickname, presence: true, length: { maximum: 10 }
 
   has_many :permissions
   has_many :tasks, through: :permissions, dependent: :delete_all

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -6,19 +6,19 @@
         <%= render "devise/shared/error_messages", resource: resource %>
         <div class = 'form-group'>
           <%= f.label :nickname, "ユーザー名" %>
-          <%= f.text_field :nickname, autofocus: true, class: "form-control" %>
+          <%= f.text_field :nickname, autofocus: true, class: "form-control", placeholder: "最大10文字", maxlength: 10 %>
         </div>
         <div class = 'form-group'>
           <%= f.label :email, "メールアドレス" %>
-          <%= f.email_field :email, autocomplete: "email", class: "form-control" %>
+          <%= f.email_field :email, autocomplete: "email", class: "form-control", placeholder: "xxx@email.com" %>
         </div>
         <div class="form-group">
           <%= f.label :password, "パスワード" %>
-          <%= f.password_field :password, autocomplete: "new-password", class: "form-control" %>
+          <%= f.password_field :password, autocomplete: "new-password", class: "form-control", placeholder: "半角英数6文字以上" %>
         </div>
         <div class="form-group">
           <%= f.label :password_confirmation, "パスワード(確認)" %>
-          <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "form-control" %>
+          <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "form-control", placeholder: "再度ご入力ください" %>
         </div>
         <%= f.submit "登録する", class: "btn btn-primary form-submit-btn" %>
         <%= link_to  "ログインはこちらから", new_user_session_path, class: "link-below-user-form" %>

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :user do
-    nickname              { Faker::Internet.username }
+    nickname              { Faker::Internet.username(specifier: 1..10) }
     email                 { Faker::Internet.free_email }
     password              { Faker::Internet.password(min_length: 6) }
     password_confirmation { password }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -16,6 +16,12 @@ RSpec.describe User, type: :model do
       expect(@user.errors.full_messages).to include("Nickname can't be blank")
     end
 
+    it 'nicknameが11文字以上だと保存できない' do
+      @user.nickname = "abcdeabcde1"
+      @user.valid?
+      expect(@user.errors.full_messages).to include("Nickname is too long (maximum is 10 characters)")
+    end
+
     it 'emailが空だと保存できない' do
       @user.email = nil
       @user.valid?

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -17,9 +17,9 @@ RSpec.describe User, type: :model do
     end
 
     it 'nicknameが11文字以上だと保存できない' do
-      @user.nickname = "abcdeabcde1"
+      @user.nickname = 'abcdeabcde1'
       @user.valid?
-      expect(@user.errors.full_messages).to include("Nickname is too long (maximum is 10 characters)")
+      expect(@user.errors.full_messages).to include('Nickname is too long (maximum is 10 characters)')
     end
 
     it 'emailが空だと保存できない' do


### PR DESCRIPTION
# Why
* ユーザー名が長いと、ログイン後のプルダウンメニューが長くなるため
* 10文字以上はなかなかいないと考えられるため（一意性制約なし かつ nickname なので）

# What
* Userモデルにバリデーションを追加
* モデルテストコードに記述を追加

close #34 