### PR TITLE
マイページ/ユーザー退会機能の実装

### DIFF
--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the users controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,4 @@
+class UsersController < ApplicationController
+  def show
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,19 @@
 class UsersController < ApplicationController
+  before_action :authenticate_user!, only: [:show]
+  before_action :set_user, only: [:show]
+  before_action :check_person, only: [:show]
+
   def show
   end
+
+  private
+
+  def set_user
+    @user = User.find(params[:id])
+  end
+
+  def check_person
+    redirect_to root_path if current_user.id != @user.id
+  end
+
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,0 +1,2 @@
+module UsersHelper
+end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -15,8 +15,8 @@
                 ユーザーID : <%= current_user.id %>
               </p>
               <div class="dropdown-divider"></div>
-              <%= link_to '#', class: "dropdown-item" do %>
-                <i class="fas fa-user-circle"></i> マイページへ
+              <%= link_to user_profile_path(current_user), class: "dropdown-item" do %>
+                <i class="fas fa-user-circle"></i> マイページ
               <% end %>
               <%= link_to '#', class: "dropdown-item" do %>
                 <i class="fas fa-user-edit"></i> アカウント情報編集

--- a/app/views/shared/_destroy_modal.html.erb
+++ b/app/views/shared/_destroy_modal.html.erb
@@ -1,19 +1,19 @@
 <div class="modal fade" id="<%= id %>" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
-    <div class="modal-dialog">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h5 class="modal-title" id="exampleModalLabel"><%= "#{target}を削除" %></h5>
-          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-            <span aria-hidden="true">&times;</span>
-          </button>
-        </div>
-        <div class="modal-body">
-          <p>この操作は取り消せません。</p>
-          <p>本当に削除しますか？</p>
-        </div>
-        <div class="modal-footer">
-          <%= link_to '削除', url, method: :delete, class: "btn btn-secondary" %>
-        </div>
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="exampleModalLabel"><%= "#{target}を削除" %></h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        <p>この操作は取り消せません。</p>
+        <p>本当に削除しますか？</p>
+      </div>
+      <div class="modal-footer">
+        <%= link_to '削除', url, method: :delete, class: "btn btn-secondary" %>
       </div>
     </div>
   </div>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,2 @@
+<h1>Users#show</h1>
+<p>Find me in app/views/users/show.html.erb</p>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,2 +1,26 @@
-<h1>Users#show</h1>
-<p>Find me in app/views/users/show.html.erb</p>
+<div class="container">
+  <h1 class="form-title">アカウント情報</h1>
+  <div class="row">
+    <div class="col-md-6 col-md-offset-3 form-wrapper">
+      <div class = 'form-group'>
+        <p style="margin-bottom: 0.5rem;">ニックネーム</p>
+        <div class="form-control">
+          <%= @user.nickname %>
+        </div>
+      </div>
+      <div class="form-group">
+        <p style="margin-bottom: 0.5rem;">メールアドレス</p>
+        <div class="form-control">
+          <%= @user.email %>
+        </div>
+      </div>
+      <%= link_to '#', class: "btn btn-primary", style: "margin-top: 25px;" do %>
+        <i class="fas fa-edit"></i> アカウント情報編集
+      <% end %></br>
+      <%= link_to '#', class:"btn btn-secondary my-2" do %>
+        退会する
+      <% end %></br>
+      <%= link_to "トップページへ戻る", root_path %>
+    </div>
+  </div>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -17,10 +17,12 @@
       <%= link_to '#', class: "btn btn-primary", style: "margin-top: 25px;" do %>
         <i class="fas fa-edit"></i> アカウント情報編集
       <% end %></br>
-      <%= link_to '#', class:"btn btn-secondary my-2" do %>
+      <%= link_to '#', class:"btn btn-secondary my-2", "data-toggle": "modal", "data-target": "#userDestroyModal" do %>
         退会する
       <% end %></br>
       <%= link_to "トップページへ戻る", root_path %>
     </div>
   </div>
+  <%# userのdestroyモーダル %>
+  <%= render partial: '/shared/destroy_modal', locals: { id: "userDestroyModal", target: "アカウント", url: user_registration_path } %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,13 +1,13 @@
 Rails.application.routes.draw do
-  get 'users/show'
   resources :tasks, except: [:index] do
     resources :commits, only: [:create, :edit, :update, :destroy]
     resources :messages, only: [:create, :destroy]
     resources :permissions, only: [:create, :destroy]
   end
-  root to: 'home#top'
   devise_for :users
   devise_scope :user do
     post 'users/guest_sign_in', to: 'users/sessions#new_guest'
   end
+  get 'users/:id/profile', to: 'users#show', as: 'user_profile'
+  root to: 'home#top'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  get 'users/show'
   resources :tasks, except: [:index] do
     resources :commits, only: [:create, :edit, :update, :destroy]
     resources :messages, only: [:create, :destroy]

--- a/spec/helpers/users_helper_spec.rb
+++ b/spec/helpers/users_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the UsersHelper. For example:
+#
+# describe UsersHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe UsersHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/users_request_spec.rb
+++ b/spec/requests/users_request_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe "Users", type: :request do
+
+  describe "GET /show" do
+    it "returns http success" do
+      get "/users/show"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/views/users/show.html.erb_spec.rb
+++ b/spec/views/users/show.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "users/show.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
# Why

* 現在のアカウントの情報を見れるようにするため

* アカウントを消去できるようにするため

# What

* マイページを実装。nicknameとemailを表示

* マイページは本人のみがアクセス可能

* マイページ内に編集ボタンと退会ボタンを実装

* 退会ボタンをクリックするとモーダル遷移。削除を押すことで退会が成立する。