### PR TITLE
ゲストユーザーを削除できないよう変更

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -7,7 +7,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   def check_guest
     if resource.email == 'guest1@gmail.com' || resource.email == 'guest2@gmail.com'
-      redirect_to root_path, alert: 'ゲストユーザーは削除できません。'
+      redirect_to user_profile_path(current_user), guest_alert: 'ゲストユーザーは削除できません。'
     end
   end
 

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -3,6 +3,13 @@
 class Users::RegistrationsController < Devise::RegistrationsController
   # before_action :configure_sign_up_params, only: [:create]
   # before_action :configure_account_update_params, only: [:update]
+  before_action :check_guest, only: :destroy
+
+  def check_guest
+    if resource.email == 'guest1@gmail.com' || resource.email == 'guest2@gmail.com'
+      redirect_to root_path, alert: 'ゲストユーザーは削除できません。'
+    end
+  end
 
   # GET /resource/sign_up
   # def new

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -7,7 +7,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   def check_guest
     if resource.email == 'guest1@gmail.com' || resource.email == 'guest2@gmail.com'
-      redirect_to user_profile_path(current_user), guest_alert: 'ゲストユーザーは削除できません。'
+      redirect_to user_profile_path(current_user), alert: 'ゲストユーザーは削除できません。'
     end
   end
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,6 +1,13 @@
 <h1 class="form-title">アカウント情報</h1>
 <div class="row">
   <div class="col-md-6 col-md-offset-3 form-wrapper">
+    <% if flash[:alert] %>
+      <div id="error_explanation">
+        <ul>
+          <li style="color: red;"><%= flash[:alert] %></li>
+        </ul>
+      </div>
+    <% end %>
     <div class = 'form-group'>
       <p style="margin-bottom: 0.5rem;">ニックネーム</p>
       <div class="form-control">

--- a/spec/system/guest_users_spec.rb
+++ b/spec/system/guest_users_spec.rb
@@ -1,20 +1,37 @@
 require 'rails_helper'
 
 RSpec.describe 'ゲストユーザーログイン', type: :system do
-  context 'ゲストユーザーでログインできる' do
-    it 'トップページのゲストログインボタンでログインできる' do
+  context 'ゲストユーザー１でログインできる' do
+    it 'トップページのゲスト１ログインボタンでログインできる' do
       # トップページへアクセス
       visit root_path
       # ゲストログインボタンを確認
-      expect(page).to have_content('ゲストログイン')
+      expect(page).to have_content('ゲスト１ログイン')
       # ログインボタンをクリック
-      find_link('ゲストログイン', href: users_guest_sign_in_path).click
+      find_link('ゲスト１ログイン', href: users_guest_sign_in_path).click
       # トップページへの遷移を確認
       expect(current_path).to eq root_path
       # ヘッダーにログインユーザーの名前があることを確認
-      expect(page).to have_content('テストユーザー')
-      # ヘッダーにゲストログイン、ログイン、新規登録のボタンがないことを確認
-      expect(page).to have_no_content('ゲストログイン')
+      expect(page).to have_content('guest1')
+      # ヘッダーにログイン、新規登録のボタンがないことを確認
+      expect(page).to have_no_content('ログイン')
+      expect(page).to have_no_content('新規登録')
+    end
+  end
+
+  context 'ゲストユーザー２でログインできる' do
+    it 'トップページのゲスト２ログインボタンでログインできる' do
+      # トップページへアクセス
+      visit root_path
+      # ゲストログインボタンを確認
+      expect(page).to have_content('ゲスト２ログイン')
+      # ログインボタンをクリック
+      find_link('ゲスト２ログイン', href: users_guest_beta_sign_in_path).click
+      # トップページへの遷移を確認
+      expect(current_path).to eq root_path
+      # ヘッダーにログインユーザーの名前があることを確認
+      expect(page).to have_content('guest2')
+      # ヘッダーにログイン、新規登録のボタンがないことを確認
       expect(page).to have_no_content('ログイン')
       expect(page).to have_no_content('新規登録')
     end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -11,10 +11,8 @@ RSpec.describe 'ユーザー新規登録', type: :system do
       visit root_path
       # 新規登録ボタンを確認
       expect(page).to have_content('新規登録')
-      # 新規登録ボタンをクリック
-      find_link('新規登録', href: new_user_registration_path).click
-      # パスを確認
-      expect(current_path).to eq new_user_registration_path
+      # 新規登録ページへ遷移
+      visit new_user_registration_path
       # フォームに値を入力
       fill_in 'user_nickname', with: @user.nickname
       fill_in 'user_email', with: @user.email
@@ -39,10 +37,8 @@ RSpec.describe 'ユーザー新規登録', type: :system do
       visit root_path
       # 新規登録ボタンを確認
       expect(page).to have_content('新規登録')
-      # 新規登録ボタンをクリック
-      find_link('新規登録', href: new_user_registration_path).click
-      # パスを確認
-      expect(current_path).to eq new_user_registration_path
+      # 新規登録ページへ遷移
+      visit new_user_registration_path
       # フォームに不正な値を入力
       fill_in 'user_nickname', with: ''
       fill_in 'user_email', with: ''
@@ -67,10 +63,8 @@ RSpec.describe 'ログイン', type: :system do
       visit root_path
       # ログインボタンを確認
       expect(page).to have_content('ログイン')
-      # ログインボタンをクリック
-      find_link('ログイン', href: new_user_session_path).click
-      # パスを確認
-      expect(current_path).to eq new_user_session_path
+      # ログインページへ遷移
+      visit new_user_session_path
       # フォームに値を入力
       fill_in 'user_email', with: @user.email
       fill_in 'user_password', with: @user.password
@@ -93,10 +87,8 @@ RSpec.describe 'ログイン', type: :system do
       visit root_path
       # ログインボタンを確認
       expect(page).to have_content('ログイン')
-      # ログインボタンをクリック
-      find_link('ログイン', href: new_user_session_path).click
-      # パスを確認
-      expect(current_path).to eq new_user_session_path
+      # ログインページへ遷移
+      visit new_user_session_path
       # フォームに値を入力
       fill_in 'user_email', with: ''
       fill_in 'user_password', with: ''


### PR DESCRIPTION
close #61 

# Why

* タスク閲覧許可をゲストユーザー間で利用する際に、ユーザーIDがわからないことによる確認の手間を省くため

# What

* deviseのResistrationsControllerにcheck_guestアクションを追加
* リダイレクト先をマイページに変更。これは「退会」ボタンがあるのがマイページのみであるため
* リダイレクトされた際のマイページにエラーメッセージを追加