### PR TITLE
レビュアーがタスク閲覧許可書を削除できる機能を実装

### DIFF
--- a/app/controllers/permissions_controller.rb
+++ b/app/controllers/permissions_controller.rb
@@ -1,6 +1,6 @@
 class PermissionsController < ApplicationController
-  before_action :authenticate_user!, only: [:create, :destroy]
-  before_action :set_task, only: [:create, :destroy]
+  before_action :authenticate_user!, only: [:create, :destroy, :reviewer_destroy]
+  before_action :set_task, only: [:create, :destroy, :reviewer_destroy]
   before_action :check_owner, only: [:create, :destroy]
 
   def create
@@ -23,6 +23,15 @@ class PermissionsController < ApplicationController
     permission = Permission.find(params[:id])
     if permission.destroy
       redirect_to task_path(@task)
+    else
+      redirect_to task_path(@task)
+    end
+  end
+
+  def reviewer_destroy
+    permission = Permission.find_by(user_id: current_user.id, task_id: @task.id)
+    if permission.destroy
+      redirect_to root_path
     else
       redirect_to task_path(@task)
     end

--- a/app/views/shared/_destroy_reviewer_modal.html.erb
+++ b/app/views/shared/_destroy_reviewer_modal.html.erb
@@ -1,0 +1,20 @@
+<div class="modal fade" id="reviewerPermissionDestroyModel" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="exampleModalLabel">このタスクの閲覧を終了します。</h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        <p>この操作は取り消せません。</p>
+        <p>再度タスクを閲覧したい場合は、</p>
+        <p>タスクオーナーに申請してください。</p>
+      </div>
+      <div class="modal-footer">
+        <%= link_to '閲覧を終了する', reviewer_permission_destroy_path(task), method: :delete, class: "btn btn-secondary" %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -14,6 +14,13 @@
             <i class="fas fa-trash-alt"></i>
           </button>
         </div>
+      <% else %>
+        <%# レビュアーがタスクを抜けるためのボタン %>
+        <div class="permission-delete-btn">
+          <%= link_to reviewer_permission_destroy_path(@task), method: :delete, class: "btn btn-secondary btn-sm" do %>
+            閲覧を終了
+          <% end %>
+        </div>
       <% end %>
     </div>
     <%# コミット部分 %>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -17,10 +17,11 @@
       <% else %>
         <%# レビュアーがタスクを抜けるためのボタン %>
         <div class="permission-delete-btn">
-          <%= link_to reviewer_permission_destroy_path(@task), method: :delete, class: "btn btn-secondary btn-sm" do %>
+          <button type="button" class="btn btn-secondary btn-sm" data-toggle="modal" data-target="#reviewerPermissionDestroyModel">
             閲覧を終了
-          <% end %>
+          </button>
         </div>
+        <%= render partial: '/shared/destroy_reviewer_modal', locals: { task: @task } %>
       <% end %>
     </div>
     <%# コミット部分 %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
     resources :messages, only: [:create, :destroy]
     resources :permissions, only: [:create, :destroy]
   end
+  delete 'tasks/:task_id/permissions_reviewer', to: 'permissions#reviewer_destroy', as: 'reviewer_permission_destroy'
   devise_for :users, controllers: {
     sessions: "users/sessions",
     registrations: "users/registrations"


### PR DESCRIPTION
# Why

* レビュアー側からタスクの閲覧を終了できるようにするため

# What

* reviewer_destroyアクションを実装
* 削除の前にモーダルを表示させて削除確認をする