### PR TITLE
dockerでgemをinstallした後のgemの永続化設定

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
     volumes:
       - .:/tasq
+      - bundle:/usr/local/bundle
     ports:
       - "3000:3000"
     depends_on:
@@ -25,3 +26,5 @@ services:
 volumes:
   mysql-data:
     driver: local
+  bundle:
+    driver: local 


### PR DESCRIPTION
## 概要

* Gemfileにgemを追加後、コンテナでbundle installをする。その後にコンテナを再起動すると、``gem not installed``のエラーが出る
* 対処法は、gemのinstall先をdocker-compose.ymlで設定すること

## 実装

* gemのinstall先の確認 : ``docker-compose run web gem environment``
  * gemのインストール先はgem environmentで表示される『INSTALLATION DIRECTORY』の項目で確認できます。
* docker-compose.yml に記述を追加

```
web:
  volumes:
    - bundle:<<ここにINSTALLATION DIRECTORYのPATHを入力>>

volumes:
  bundle:
    driver: local
```

* もう一度イメージビルド : ``docker-compose build``
* Gemfileにgemを追加
* gem install : ``docker-compose run web bundle install``